### PR TITLE
Set directory perms to match run_user and run_group

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,8 +52,8 @@ class dropwizard (
   if ! defined(File[$config_path]) {
     file { $config_path:
       ensure => directory,
-      owner  => 'root',
-      group  => 'root',
+      owner  => $run_user,
+      group  => $run_group,
       mode   => '0755',
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -29,6 +29,12 @@ describe 'dropwizard' do
               it { should contain_group('dropwizard').with_system(true) }
 
               it { should contain_class('java') }
+              it { should contain_file('/etc/dropwizard').with({
+                'owner' => 'dropwizard',
+                'group' => 'dropwizard',
+                'mode'  => '0755',
+              })}
+
             end
 
           end


### PR DESCRIPTION
This was causing issues in our implementation: since the directory defaults to `root:root`, the daemon was unable to start. This change should fix that.
