### PR TITLE
Adding in before statement for ordering purposes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,6 +55,7 @@ class dropwizard (
       owner  => $run_user,
       group  => $run_group,
       mode   => '0755',
+      before => Class['::java'],
     }
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "thanandorn-dropwizard",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Tron Thongsringklee",
   "summary": "Dropwizard Puppet Module",
   "license": "MIT",


### PR DESCRIPTION
Adding in before statement for ordering, am hitting issues where with a large java install, resources are created out of order, causing the configuration folder to be owned by root, and not readable by the dropwizard user