### PR TITLE
Add a validate_cmd to config file resource

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
   forge_modules:
-    java: "puppetlabs-java"
+    java:
+      repo: "puppetlabs/java"
+      ref: "1.6.0"
     stdlib: "puppetlabs-stdlib"
   symlinks:
     dropwizard: "#{source_dir}"

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -11,6 +11,7 @@ define dropwizard::instance (
   $base_path       = $::dropwizard::base_path,
   $sysconfig_path  = $::dropwizard::sysconfig_path,
   $config_path     = $::dropwizard::config_path,
+  $config_test     = false,
   $config_files    = [],
   $config_hash     = {
     'server' => {
@@ -46,6 +47,11 @@ define dropwizard::instance (
     default  => 'present',
   }
 
+  #Set validate_cmd
+  if $config_test {
+    $validate_cmd = "su - ${user} -c \"/bin/java -jar ${jar_file} check %\""
+  }
+
   file { "${sysconfig_path}/dropwizard_${name}":
     ensure  => $file_ensure,
     owner   => 'root',
@@ -56,13 +62,14 @@ define dropwizard::instance (
   }
 
   file { "${config_path}/${name}.yaml":
-    ensure  => $file_ensure,
-    owner   => $user,
-    group   => $group,
-    mode    => $mode,
-    content => inline_template('<%= @config_hash.to_yaml.gsub("---\n", "") %>'),
-    require => File[$config_path,"${sysconfig_path}/dropwizard_${name}"],
-    notify  => Service["dropwizard_${name}"],
+    ensure       => $file_ensure,
+    owner        => $user,
+    group        => $group,
+    mode         => $mode,
+    content      => inline_template('<%= @config_hash.to_yaml.gsub("---\n", "") %>'),
+    require      => File[$config_path,"${sysconfig_path}/dropwizard_${name}"],
+    validate_cmd => $validate_cmd,
+    notify       => Service["dropwizard_${name}"],
   }
 
   # Assign default jar

--- a/templates/service/dropwizard.systemd.erb
+++ b/templates/service/dropwizard.systemd.erb
@@ -13,4 +13,3 @@ RestartSec=30s
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
Hi Tron,

Awesome module! I ran into a problem lately where deploying a config change caused services to fail at restart but Puppet to carry on happily and Jenkins to deploy these changes throughout the (non-production) environments with no problem.

We could be a bit more defensive and validate the file before it gets copied in place using the Dropwizard check command. I've added the ability to enable / disable this by setting `$config_test` on the `dropwizard::instance` you want to check. 

On reflection I think that `Restart=on-failure` in the systemd unit might be a part of the problem too. Maybe `Restart=on-abnormal` would be a better option so that if the Dropwizard server command fails to start and exits != 0 Puppet should (might) pick up this failure?

Any feedback would be greatly appreciated. 

Thanks, 

Tim. 